### PR TITLE
squick: fix package path handling

### DIFF
--- a/cmd/squick/main.go
+++ b/cmd/squick/main.go
@@ -48,8 +48,10 @@ func main() {
 		flag.Parse(os.Args[2:])
 
 		pkg := "database"
+		pkgPath := []string{".", "database"}
 		if args := flag.Args(); len(args) > 0 {
-			pkg = args[0]
+			pkgPath = strings.Split(args[0], "/")
+			pkg = pkgPath[len(pkgPath)-1]
 		}
 
 		if *force {
@@ -63,11 +65,12 @@ func main() {
 		}
 
 		ctx := squick.Context{
-			MaxOpen: *maxOpen,
-			MaxIdle: *maxIdle,
-			Ping:    *ping,
-			Driver:  driver,
-			Package: pkg,
+			MaxOpen:     *maxOpen,
+			MaxIdle:     *maxIdle,
+			Ping:        *ping,
+			Driver:      driverName,
+			Package:     pkg,
+			PackagePath: pkgPath,
 		}
 		if err := sq.Init(ctx); err != nil {
 			log.Fatal(err)

--- a/squick.go
+++ b/squick.go
@@ -7,6 +7,7 @@ import (
 	"go/format"
 	"log"
 	"os"
+	"path"
 	"text/template"
 
 	"github.com/go-openapi/swag"
@@ -40,6 +41,7 @@ type Context struct {
 	NoPK         bool
 	Driver       string
 	Package      string
+	PackagePath  []string
 	Model        string
 	Tags         []string
 	UpdatedField string
@@ -66,10 +68,10 @@ func New() (*Squick, error) {
 }
 
 func (s *Squick) Init(ctx Context) error {
-	if _, err := os.Stat(ctx.Package); errors.Is(err, os.ErrExist) {
+	if _, err := os.Stat(path.Join(ctx.PackagePath...)); errors.Is(err, os.ErrExist) {
 		return err
 	}
-	if err := os.Mkdir(ctx.Package, 0700); err != nil {
+	if err := os.Mkdir(path.Join(ctx.PackagePath...), 0700); err != nil {
 		return err
 	}
 
@@ -83,7 +85,7 @@ func (s *Squick) Init(ctx Context) error {
 		return err
 	}
 
-	return os.WriteFile(fmt.Sprintf("%s/%s.go", ctx.Package, ctx.Package), data, 0700)
+	return os.WriteFile(fmt.Sprintf("%s/%s.go", path.Join(ctx.PackagePath...), ctx.Package), data, 0700)
 }
 
 func (s *Squick) Make(ctx Context, stmt Stmt) error {


### PR DESCRIPTION
if path isn't in current working directory, it passed to the templates as-is, producing invalid generated code